### PR TITLE
Update docker and planetscale

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "jsonschema": "^1.4.1"
   },
   "name": "service-status-data",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Endpoints for services that have status pages",
   "main": "index.js",
   "scripts": {

--- a/services/docker.json
+++ b/services/docker.json
@@ -3,6 +3,6 @@
   "web": "https://status.docker.com/",
   "host": "status.io",
   "urls": {
-    "status": "https://status.docker.com/1.0/status/533c6539221ae15e3f000031"
+    "status": "https://www.dockerstatus.com/"
   }
 }

--- a/services/planetscale.json
+++ b/services/planetscale.json
@@ -1,6 +1,6 @@
 {
     "name": "PlanetScale",
     "web": "https://www.planetscalestatus.com/",
-    "host": "atlassian"
+    "host": "incident.io"
 }
   


### PR DESCRIPTION
* The old URL for Docker wasn't working and couldn't spot a nice way to get an API from Docker, so will fall back to parsing HTMl.
* Planetscale moved from Atlassian to Incident.io.